### PR TITLE
Use files block instead of distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,12 +73,9 @@ jreleaser {
             apiEndpoint = 'https://api.github.com'
         }
     }
-    distributions {
-        app {
-            distributionType = 'BINARY'
-            artifact {
-                path = 'build/docs/asciidocPdf/gis-schnittstellen.pdf'
-            }
+    files {
+        artifact {
+            path = 'build/docs/asciidocPdf/gis-schnittstellen.pdf'
         }
     }
 }


### PR DESCRIPTION
Distributions must follow a file structure. BINARY distributions must be Zip or Tar files https://jreleaser.org/guide/latest/distributions/binary.html
In this case the release contains a PDF file which should be uploaded as a file, not as a distribution.

Moreover, you may skip defining `owner:` and `apiEndpoint:` as these values are taken directly from the git metadata.